### PR TITLE
Depend on the Qiskit metapackage instead of qiskit-terra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,8 @@ homepage = "https://github.com/tergite/tergite"
 [tool.poetry.dependencies]
 python = "^3.8"
 requests = ">=2.25.1"
-qiskit-terra = "0.22.0"
+qiskit = "0.39"
 pandas = ">=1.4.2"
-qiskit-aer = ">=0.11.0"
-qiskit-experiments = ">=0.4.0"
-qiskit-ibmq-provider = ">=0.19.2"
 qiskit-ignis = ">=0.7.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Qiskit is moving away from the metapackage model. For this reason, it is better to depend on `qiskit` instead of the individual components.

| Qiskit Metapackage Version | qiskit-terra | qiskit-aer | qiskit-ibmq-provider |  Release Date |
|:--------------------------:|:--------------------:|:------------:|:--------------------:|:-----------:|
| 0.39.5                     | 0.22.4       | 0.11.2     |  0.19.2 | 2023-01-17   |
| 0.39.4                     | 0.22.3       | 0.11.2     |  0.19.2 | 2022-12-08   |
| 0.39.3                     | 0.22.3       | 0.11.1     | 0.19.2 | 2022-11-25   |
| 0.39.2                     | 0.22.2       | 0.11.1     |  0.19.2 | 2022-11-03   |
| 0.39.1                     | 0.22.1       | 0.11.1     |  0.19.2 | 2022-11-02   |
| 0.39.0                     | 0.22.0       | 0.11.0     |  0.19.2 | 2022-10-13   |
